### PR TITLE
feat: added possibility to use a OpenAPI or a smithy to define an API

### DIFF
--- a/.header.md
+++ b/.header.md
@@ -145,6 +145,112 @@ module "agentcore" {
 }
 ```
 
+## Basic Usage - Create Gateway Target with Lambda
+
+```hcl
+module "agentcore" {
+  source = "aws-ia/agentcore/aws"
+  # First create a gateway
+  gateways = {
+    my_gateway = {
+      description   = "Gateway for external tools"
+      protocol_type = "MCP"
+    }
+  }
+  # Then create a gateway target
+  gateway_targets = {
+    lambda_target = {
+      gateway_name = "my_gateway"
+      description  = "Lambda function target"
+      type         = "LAMBDA"
+      lambda_config = {
+        lambda_arn       = "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+        tool_schema_type = "INLINE"
+        inline_schema = {
+          name        = "process_data"
+          description = "Process data using Lambda"
+          input_schema = {
+            type        = "string"
+            description = "Input data to process"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Basic Usage - Create Gateway Target with OpenAPI Schema
+
+```hcl
+module "agentcore" {
+  source = "aws-ia/agentcore/aws"
+  gateways = {
+    api_gateway = {
+      description   = "Gateway for REST APIs"
+      protocol_type = "MCP"
+    }
+  }
+  gateway_targets = {
+    openapi_target = {
+      gateway_name = "api_gateway"
+      description  = "REST API via OpenAPI schema"
+      type         = "OPEN_API_SCHEMA"
+      open_api_schema_config = {
+        inline_payload = {
+          payload = jsonencode({
+            openapi = "3.0.0"
+            info = {
+              title   = "Example API"
+              version = "1.0.0"
+            }
+            paths = {
+              "/api/resource" = {
+                get = {
+                  summary = "Get resource"
+                  responses = {
+                    "200" = {
+                      description = "Success"
+                    }
+                  }
+                }
+              }
+            }
+          })
+        }
+      }
+    }
+  }
+}
+```
+
+## Basic Usage - Create Gateway Target with Smithy Model
+
+```hcl
+module "agentcore" {
+  source = "aws-ia/agentcore/aws"
+  gateways = {
+    smithy_gateway = {
+      description   = "Gateway for Smithy services"
+      protocol_type = "MCP"
+    }
+  }
+  gateway_targets = {
+    smithy_target = {
+      gateway_name = "smithy_gateway"
+      description  = "Service via Smithy model"
+      type         = "SMITHY_MODEL"
+      smithy_model_config = {
+        s3 = {
+          uri                     = "s3://my-bucket/models/service.smithy"
+          bucket_owner_account_id = "123456789012"
+        }
+      }
+    }
+  }
+}
+```
+
 ## Examples
 
 The module includes several examples demonstrating different use cases:

--- a/README.md
+++ b/README.md
@@ -146,6 +146,112 @@ module "agentcore" {
 }
 ```
 
+## Basic Usage - Create Gateway Target with Lambda
+
+```hcl
+module "agentcore" {
+  source = "aws-ia/agentcore/aws"
+  # First create a gateway
+  gateways = {
+    my_gateway = {
+      description   = "Gateway for external tools"
+      protocol_type = "MCP"
+    }
+  }
+  # Then create a gateway target
+  gateway_targets = {
+    lambda_target = {
+      gateway_name = "my_gateway"
+      description  = "Lambda function target"
+      type         = "LAMBDA"
+      lambda_config = {
+        lambda_arn       = "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+        tool_schema_type = "INLINE"
+        inline_schema = {
+          name        = "process_data"
+          description = "Process data using Lambda"
+          input_schema = {
+            type        = "string"
+            description = "Input data to process"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Basic Usage - Create Gateway Target with OpenAPI Schema
+
+```hcl
+module "agentcore" {
+  source = "aws-ia/agentcore/aws"
+  gateways = {
+    api_gateway = {
+      description   = "Gateway for REST APIs"
+      protocol_type = "MCP"
+    }
+  }
+  gateway_targets = {
+    openapi_target = {
+      gateway_name = "api_gateway"
+      description  = "REST API via OpenAPI schema"
+      type         = "OPEN_API_SCHEMA"
+      open_api_schema_config = {
+        inline_payload = {
+          payload = jsonencode({
+            openapi = "3.0.0"
+            info = {
+              title   = "Example API"
+              version = "1.0.0"
+            }
+            paths = {
+              "/api/resource" = {
+                get = {
+                  summary = "Get resource"
+                  responses = {
+                    "200" = {
+                      description = "Success"
+                    }
+                  }
+                }
+              }
+            }
+          })
+        }
+      }
+    }
+  }
+}
+```
+
+## Basic Usage - Create Gateway Target with Smithy Model
+
+```hcl
+module "agentcore" {
+  source = "aws-ia/agentcore/aws"
+  gateways = {
+    smithy_gateway = {
+      description   = "Gateway for Smithy services"
+      protocol_type = "MCP"
+    }
+  }
+  gateway_targets = {
+    smithy_target = {
+      gateway_name = "smithy_gateway"
+      description  = "Service via Smithy model"
+      type         = "SMITHY_MODEL"
+      smithy_model_config = {
+        s3 = {
+          uri                     = "s3://my-bucket/models/service.smithy"
+          bucket_owner_account_id = "123456789012"
+        }
+      }
+    }
+  }
+}
+```
+
 ## Examples
 
 The module includes several examples demonstrating different use cases:
@@ -255,14 +361,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_browsers"></a> [browsers](#input\_browsers) | Map of AgentCore custom browsers to create. Each key is the browser name. | <pre>map(object({<br/>    description          = optional(string)<br/>    execution_role_arn   = optional(string)<br/>    network_mode         = optional(string, "PUBLIC")<br/>    <br/>    network_configuration = optional(object({<br/>      security_groups = list(string)<br/>      subnets         = list(string)<br/>    }))<br/>    <br/>    recording_enabled = optional(bool, false)<br/>    <br/>    recording_config = optional(object({<br/>      bucket = string<br/>      prefix = string<br/>    }))<br/>    <br/>    tags = optional(map(string))<br/>  }))</pre> | `{}` | no |
-| <a name="input_code_interpreters"></a> [code\_interpreters](#input\_code\_interpreters) | Map of AgentCore custom code interpreters to create. Each key is the interpreter name. | <pre>map(object({<br/>    description          = optional(string)<br/>    execution_role_arn   = optional(string)<br/>    network_mode         = optional(string, "SANDBOX")<br/>    <br/>    network_configuration = optional(object({<br/>      security_groups = list(string)<br/>      subnets         = list(string)<br/>    }))<br/>    <br/>    tags = optional(map(string))<br/>  }))</pre> | `{}` | no |
+| <a name="input_browsers"></a> [browsers](#input\_browsers) | Map of AgentCore custom browsers to create. Each key is the browser name. | <pre>map(object({<br/>    description        = optional(string)<br/>    execution_role_arn = optional(string)<br/>    network_mode       = optional(string, "PUBLIC")<br/><br/>    network_configuration = optional(object({<br/>      security_groups = list(string)<br/>      subnets         = list(string)<br/>    }))<br/><br/>    recording_enabled = optional(bool, false)<br/><br/>    recording_config = optional(object({<br/>      bucket = string<br/>      prefix = string<br/>    }))<br/><br/>    tags = optional(map(string))<br/>  }))</pre> | `{}` | no |
+| <a name="input_code_interpreters"></a> [code\_interpreters](#input\_code\_interpreters) | Map of AgentCore custom code interpreters to create. Each key is the interpreter name. | <pre>map(object({<br/>    description        = optional(string)<br/>    execution_role_arn = optional(string)<br/>    network_mode       = optional(string, "SANDBOX")<br/><br/>    network_configuration = optional(object({<br/>      security_groups = list(string)<br/>      subnets         = list(string)<br/>    }))<br/><br/>    tags = optional(map(string))<br/>  }))</pre> | `{}` | no |
 | <a name="input_debug"></a> [debug](#input\_debug) | Enable debug mode: generates .env files with actual resource IDs in code\_source\_path directories for local testing. | `bool` | `false` | no |
-| <a name="input_gateway_targets"></a> [gateway\_targets](#input\_gateway\_targets) | Map of AgentCore gateway targets to create. Each key is the target name. | <pre>map(object({<br/>    gateway_name                = string<br/>    description                 = optional(string)<br/>    credential_provider_type    = optional(string)<br/>    <br/>    api_key_config = optional(object({<br/>      provider_arn              = string<br/>      credential_location       = string<br/>      credential_parameter_name = string<br/>      credential_prefix         = optional(string)<br/>    }))<br/>    <br/>    oauth_config = optional(object({<br/>      provider_arn      = string<br/>      scopes            = optional(list(string))<br/>      custom_parameters = optional(map(string))<br/>    }))<br/>    <br/>    type = string # "LAMBDA" or "MCP_SERVER"<br/>    <br/>    lambda_config = optional(object({<br/>      lambda_arn       = string<br/>      tool_schema_type = string # "INLINE" or "S3"<br/>      <br/>      inline_schema = optional(object({<br/>        name        = string<br/>        description = optional(string)<br/>        <br/>        input_schema = object({<br/>          type        = string<br/>          description = optional(string)<br/>          properties  = optional(list(any))<br/>          items       = optional(any)<br/>        })<br/>        <br/>        output_schema = optional(object({<br/>          type        = string<br/>          description = optional(string)<br/>          properties  = optional(list(any))<br/>          items       = optional(any)<br/>        }))<br/>      }))<br/>      <br/>      s3_schema = optional(object({<br/>        uri                     = string<br/>        bucket_owner_account_id = optional(string)<br/>      }))<br/>    }))<br/>    <br/>    mcp_server_config = optional(object({<br/>      endpoint = string<br/>    }))<br/>  }))</pre> | `{}` | no |
-| <a name="input_gateways"></a> [gateways](#input\_gateways) | Map of AgentCore gateways to create. Each key is the gateway name. | <pre>map(object({<br/>    description      = optional(string)<br/>    role_arn         = optional(string)<br/>    authorizer_type  = optional(string, "AWS_IAM")<br/>    protocol_type    = optional(string, "MCP")<br/>    exception_level  = optional(string, "DEBUG")<br/>    kms_key_arn      = optional(string)<br/>    <br/>    authorizer_configuration = optional(object({<br/>      custom_jwt_authorizer = object({<br/>        allowed_audience = list(string)<br/>        allowed_clients  = optional(list(string))<br/>        discovery_url    = string<br/>      })<br/>    }))<br/>    <br/>    protocol_configuration = optional(object({<br/>      mcp = object({<br/>        instructions       = optional(string)<br/>        search_type        = optional(string, "SEMANTIC")<br/>        supported_versions = optional(list(string), ["1.0.0"])<br/>      })<br/>    }))<br/>    <br/>    interceptor_configurations = optional(list(object({<br/>      interception_points = list(string)<br/>      interceptor = object({<br/>        lambda = object({<br/>          arn = string<br/>        })<br/>      })<br/>      input_configuration = optional(object({<br/>        pass_request_headers = optional(bool, false)<br/>      }))<br/>    })), [])<br/>    <br/>    tags = optional(map(string))<br/>  }))</pre> | `{}` | no |
-| <a name="input_memories"></a> [memories](#input\_memories) | Map of AgentCore memories to create. Each key is the memory name. NOTE: Each memory can only have ONE strategy. | <pre>map(object({<br/>    description           = optional(string)<br/>    event_expiry_duration = optional(number, 90)<br/>    execution_role_arn    = optional(string)<br/>    encryption_key_arn    = optional(string)<br/>    <br/>    strategies = optional(list(object({<br/>      semantic_memory_strategy = optional(object({<br/>        name        = optional(string)<br/>        description = optional(string)<br/>        namespaces  = optional(list(string))<br/>      }))<br/>      summary_memory_strategy = optional(object({<br/>        name        = optional(string)<br/>        description = optional(string)<br/>        namespaces  = optional(list(string))<br/>      }))<br/>      user_preference_memory_strategy = optional(object({<br/>        name        = optional(string)<br/>        description = optional(string)<br/>        namespaces  = optional(list(string))<br/>      }))<br/>      custom_memory_strategy = optional(object({<br/>        name        = optional(string)<br/>        description = optional(string)<br/>        namespaces  = optional(list(string))<br/>        configuration = optional(object({<br/>          self_managed_configuration = optional(object({<br/>            historical_context_window_size = optional(number, 4)<br/>            invocation_configuration = object({<br/>              payload_delivery_bucket_name = string<br/>              topic_arn                    = string<br/>            })<br/>            trigger_conditions = optional(list(object({<br/>              message_based_trigger = optional(object({<br/>                message_count = optional(number, 1)<br/>              }))<br/>              time_based_trigger = optional(object({<br/>                idle_session_timeout = optional(number, 10)<br/>              }))<br/>              token_based_trigger = optional(object({<br/>                token_count = optional(number, 100)<br/>              }))<br/>            })))<br/>          }))<br/>          semantic_override = optional(object({<br/>            consolidation = optional(object({<br/>              append_to_prompt = optional(string)<br/>              model_id         = optional(string)<br/>            }))<br/>            extraction = optional(object({<br/>              append_to_prompt = optional(string)<br/>              model_id         = optional(string)<br/>            }))<br/>          }))<br/>          summary_override = optional(object({<br/>            consolidation = optional(object({<br/>              append_to_prompt = optional(string)<br/>              model_id         = optional(string)<br/>            }))<br/>          }))<br/>          user_preference_override = optional(object({<br/>            consolidation = optional(object({<br/>              append_to_prompt = optional(string)<br/>              model_id         = optional(string)<br/>            }))<br/>            extraction = optional(object({<br/>              append_to_prompt = optional(string)<br/>              model_id         = optional(string)<br/>            }))<br/>          }))<br/>        }))<br/>      }))<br/>    })), [])<br/>    <br/>    tags = optional(map(string))<br/>  }))</pre> | `{}` | no |
+| <a name="input_gateway_targets"></a> [gateway\_targets](#input\_gateway\_targets) | Map of AgentCore gateway targets to create. Each key is the target name. | <pre>map(object({<br/>    gateway_name             = string<br/>    description              = optional(string)<br/>    credential_provider_type = optional(string)<br/><br/>    api_key_config = optional(object({<br/>      provider_arn              = string<br/>      credential_location       = string<br/>      credential_parameter_name = string<br/>      credential_prefix         = optional(string)<br/>    }))<br/><br/>    oauth_config = optional(object({<br/>      provider_arn      = string<br/>      scopes            = optional(list(string))<br/>      custom_parameters = optional(map(string))<br/>    }))<br/><br/>    type = string # "LAMBDA", "MCP_SERVER", "OPEN_API_SCHEMA", or "SMITHY_MODEL"<br/><br/>    lambda_config = optional(object({<br/>      lambda_arn       = string<br/>      tool_schema_type = string # "INLINE" or "S3"<br/><br/>      inline_schema = optional(object({<br/>        name        = string<br/>        description = optional(string)<br/><br/>        input_schema = object({<br/>          type        = string<br/>          description = optional(string)<br/>          properties  = optional(list(any))<br/>          items       = optional(any)<br/>        })<br/><br/>        output_schema = optional(object({<br/>          type        = string<br/>          description = optional(string)<br/>          properties  = optional(list(any))<br/>          items       = optional(any)<br/>        }))<br/>      }))<br/><br/>      s3_schema = optional(object({<br/>        uri                     = string<br/>        bucket_owner_account_id = optional(string)<br/>      }))<br/>    }))<br/><br/>    mcp_server_config = optional(object({<br/>      endpoint = string<br/>    }))<br/><br/>    open_api_schema_config = optional(object({<br/>      inline_payload = optional(object({<br/>        payload = string<br/>      }))<br/>      s3 = optional(object({<br/>        uri                     = string<br/>        bucket_owner_account_id = optional(string)<br/>      }))<br/>    }))<br/><br/>    smithy_model_config = optional(object({<br/>      inline_payload = optional(object({<br/>        payload = string<br/>      }))<br/>      s3 = optional(object({<br/>        uri                     = string<br/>        bucket_owner_account_id = optional(string)<br/>      }))<br/>    }))<br/>  }))</pre> | `{}` | no |
+| <a name="input_gateways"></a> [gateways](#input\_gateways) | Map of AgentCore gateways to create. Each key is the gateway name. | <pre>map(object({<br/>    description     = optional(string)<br/>    role_arn        = optional(string)<br/>    authorizer_type = optional(string, "AWS_IAM")<br/>    protocol_type   = optional(string, "MCP")<br/>    exception_level = optional(string, "DEBUG")<br/>    kms_key_arn     = optional(string)<br/><br/>    authorizer_configuration = optional(object({<br/>      custom_jwt_authorizer = object({<br/>        allowed_audience = list(string)<br/>        allowed_clients  = optional(list(string))<br/>        discovery_url    = string<br/>      })<br/>    }))<br/><br/>    protocol_configuration = optional(object({<br/>      mcp = object({<br/>        instructions       = optional(string)<br/>        search_type        = optional(string, "SEMANTIC")<br/>        supported_versions = optional(list(string), ["1.0.0"])<br/>      })<br/>    }))<br/><br/>    interceptor_configurations = optional(list(object({<br/>      interception_points = list(string)<br/>      interceptor = object({<br/>        lambda = object({<br/>          arn = string<br/>        })<br/>      })<br/>      input_configuration = optional(object({<br/>        pass_request_headers = optional(bool, false)<br/>      }))<br/>    })), [])<br/><br/>    tags = optional(map(string))<br/>  }))</pre> | `{}` | no |
+| <a name="input_memories"></a> [memories](#input\_memories) | Map of AgentCore memories to create. Each key is the memory name. NOTE: Each memory can only have ONE strategy. | <pre>map(object({<br/>    description           = optional(string)<br/>    event_expiry_duration = optional(number, 90)<br/>    execution_role_arn    = optional(string)<br/>    encryption_key_arn    = optional(string)<br/><br/>    strategies = optional(list(object({<br/>      semantic_memory_strategy = optional(object({<br/>        name        = optional(string)<br/>        description = optional(string)<br/>        namespaces  = optional(list(string))<br/>      }))<br/>      summary_memory_strategy = optional(object({<br/>        name        = optional(string)<br/>        description = optional(string)<br/>        namespaces  = optional(list(string))<br/>      }))<br/>      user_preference_memory_strategy = optional(object({<br/>        name        = optional(string)<br/>        description = optional(string)<br/>        namespaces  = optional(list(string))<br/>      }))<br/>      custom_memory_strategy = optional(object({<br/>        name        = optional(string)<br/>        description = optional(string)<br/>        namespaces  = optional(list(string))<br/>        configuration = optional(object({<br/>          self_managed_configuration = optional(object({<br/>            historical_context_window_size = optional(number, 4)<br/>            invocation_configuration = object({<br/>              payload_delivery_bucket_name = string<br/>              topic_arn                    = string<br/>            })<br/>            trigger_conditions = optional(list(object({<br/>              message_based_trigger = optional(object({<br/>                message_count = optional(number, 1)<br/>              }))<br/>              time_based_trigger = optional(object({<br/>                idle_session_timeout = optional(number, 10)<br/>              }))<br/>              token_based_trigger = optional(object({<br/>                token_count = optional(number, 100)<br/>              }))<br/>            })))<br/>          }))<br/>          semantic_override = optional(object({<br/>            consolidation = optional(object({<br/>              append_to_prompt = optional(string)<br/>              model_id         = optional(string)<br/>            }))<br/>            extraction = optional(object({<br/>              append_to_prompt = optional(string)<br/>              model_id         = optional(string)<br/>            }))<br/>          }))<br/>          summary_override = optional(object({<br/>            consolidation = optional(object({<br/>              append_to_prompt = optional(string)<br/>              model_id         = optional(string)<br/>            }))<br/>          }))<br/>          user_preference_override = optional(object({<br/>            consolidation = optional(object({<br/>              append_to_prompt = optional(string)<br/>              model_id         = optional(string)<br/>            }))<br/>            extraction = optional(object({<br/>              append_to_prompt = optional(string)<br/>              model_id         = optional(string)<br/>            }))<br/>          }))<br/>        }))<br/>      }))<br/>    })), [])<br/><br/>    tags = optional(map(string))<br/>  }))</pre> | `{}` | no |
 | <a name="input_project_prefix"></a> [project\_prefix](#input\_project\_prefix) | Prefix for all AWS resource names created by this module. Helps identify and organize resources. | `string` | `"agentcore"` | no |
-| <a name="input_runtimes"></a> [runtimes](#input\_runtimes) | Map of AgentCore runtimes to create. Each key is the runtime name. | <pre>map(object({<br/>    source_type = string # "CODE" or "CONTAINER"<br/><br/>    # CODE: Module-managed (provide source_path)<br/>    code_source_path = optional(string)<br/><br/>    # CODE: User-managed (provide s3_bucket)<br/>    code_s3_bucket     = optional(string)<br/>    code_s3_key        = optional(string)<br/>    code_s3_version_id = optional(string)<br/><br/>    # CODE: Required for both<br/>    code_entry_point = optional(list(string))<br/>    code_runtime     = optional(string, "PYTHON_3_11") # Default to PYTHON_3_11<br/><br/>    # CONTAINER: Module-managed (provide source_path)<br/>    container_source_path     = optional(string)<br/>    container_dockerfile_name = optional(string, "Dockerfile")<br/>    container_image_tag       = optional(string, "latest")<br/><br/>    # CONTAINER: User-managed (provide image_uri)<br/>    container_image_uri = optional(string)<br/><br/>    # Shared configuration<br/>    execution_role_arn       = optional(string) # Required for user-managed<br/>    description              = optional(string)<br/>    execution_network_mode   = optional(string, "PUBLIC")<br/>    execution_network_config = optional(object({<br/>      security_groups = list(string)<br/>      subnets         = list(string)<br/>    }))<br/>    environment_variables = optional(map(string), {})<br/><br/>    create_endpoint      = optional(bool, true)<br/>    endpoint_description = optional(string)<br/>    tags                 = optional(map(string))<br/>  }))</pre> | `{}` | no |
+| <a name="input_runtimes"></a> [runtimes](#input\_runtimes) | Map of AgentCore runtimes to create. Each key is the runtime name. | <pre>map(object({<br/>    source_type = string # "CODE" or "CONTAINER"<br/><br/>    # CODE: Module-managed (provide source_path)<br/>    code_source_path = optional(string)<br/><br/>    # CODE: User-managed (provide s3_bucket)<br/>    code_s3_bucket     = optional(string)<br/>    code_s3_key        = optional(string)<br/>    code_s3_version_id = optional(string)<br/><br/>    # CODE: Required for both<br/>    code_entry_point = optional(list(string))<br/>    code_runtime     = optional(string, "PYTHON_3_11") # Default to PYTHON_3_11<br/><br/>    # CONTAINER: Module-managed (provide source_path)<br/>    container_source_path     = optional(string)<br/>    container_dockerfile_name = optional(string, "Dockerfile")<br/>    container_image_tag       = optional(string, "latest")<br/><br/>    # CONTAINER: User-managed (provide image_uri)<br/>    container_image_uri = optional(string)<br/><br/>    # Shared configuration<br/>    execution_role_arn     = optional(string) # Required for user-managed<br/>    description            = optional(string)<br/>    execution_network_mode = optional(string, "PUBLIC")<br/>    execution_network_config = optional(object({<br/>      security_groups = list(string)<br/>      subnets         = list(string)<br/>    }))<br/>    environment_variables = optional(map(string), {})<br/><br/>    create_endpoint      = optional(bool, true)<br/>    endpoint_description = optional(string)<br/>    tags                 = optional(map(string))<br/>  }))</pre> | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources created by this module. | `map(string)` | <pre>{<br/>  "IaC": "Terraform",<br/>  "ModuleName": "terraform-aws-agentcore",<br/>  "ModuleSource": "https://github.com/aws-ia/terraform-aws-agentcore",<br/>  "ModuleVersion": ""<br/>}</pre> | no |
 
 ## Outputs

--- a/gateway.tf
+++ b/gateway.tf
@@ -7,13 +7,13 @@
 resource "awscc_bedrockagentcore_gateway" "gateway" {
   for_each = var.gateways
 
-  name             = each.key
-  description      = each.value.description
-  role_arn         = each.value.role_arn != null ? each.value.role_arn : aws_iam_role.gateway[each.key].arn
-  authorizer_type  = each.value.authorizer_type
-  protocol_type    = each.value.protocol_type
-  exception_level  = each.value.exception_level
-  kms_key_arn      = each.value.kms_key_arn
+  name            = each.key
+  description     = each.value.description
+  role_arn        = each.value.role_arn != null ? each.value.role_arn : aws_iam_role.gateway[each.key].arn
+  authorizer_type = each.value.authorizer_type
+  protocol_type   = each.value.protocol_type
+  exception_level = each.value.exception_level
+  kms_key_arn     = each.value.kms_key_arn
 
   authorizer_configuration = each.value.authorizer_type == "CUSTOM_JWT" && each.value.authorizer_configuration != null ? {
     custom_jwt_authorizer = {
@@ -191,6 +191,47 @@ resource "aws_bedrockagentcore_gateway_target" "gateway_target" {
         for_each = each.value.type == "MCP_SERVER" && each.value.mcp_server_config != null ? [1] : []
         content {
           endpoint = each.value.mcp_server_config.endpoint
+        }
+      }
+
+
+      dynamic "open_api_schema" {
+        for_each = each.value.type == "OPEN_API_SCHEMA" && each.value.open_api_schema_config != null ? [1] : []
+
+        content {
+          dynamic "inline_payload" {
+            for_each = each.value.open_api_schema_config.inline_payload != null ? [1] : []
+            content {
+              payload = each.value.open_api_schema_config.inline_payload.payload
+            }
+          }
+          dynamic "s3" {
+            for_each = each.value.open_api_schema_config.s3 != null ? [1] : []
+            content {
+              uri                     = each.value.open_api_schema_config.s3.uri
+              bucket_owner_account_id = each.value.open_api_schema_config.s3.bucket_owner_account_id
+            }
+          }
+        }
+      }
+
+      dynamic "smithy_model" {
+        for_each = each.value.type == "SMITHY_MODEL" && each.value.smithy_model_config != null ? [1] : []
+
+        content {
+          dynamic "inline_payload" {
+            for_each = each.value.smithy_model_config.inline_payload != null ? [1] : []
+            content {
+              payload = each.value.smithy_model_config.inline_payload.payload
+            }
+          }
+          dynamic "s3" {
+            for_each = each.value.smithy_model_config.s3 != null ? [1] : []
+            content {
+              uri                     = each.value.smithy_model_config.s3.uri
+              bucket_owner_account_id = each.value.smithy_model_config.s3.bucket_owner_account_id
+            }
+          }
         }
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -53,9 +53,9 @@ variable "runtimes" {
     container_image_uri = optional(string)
 
     # Shared configuration
-    execution_role_arn       = optional(string) # Required for user-managed
-    description              = optional(string)
-    execution_network_mode   = optional(string, "PUBLIC")
+    execution_role_arn     = optional(string) # Required for user-managed
+    description            = optional(string)
+    execution_network_mode = optional(string, "PUBLIC")
     execution_network_config = optional(object({
       security_groups = list(string)
       subnets         = list(string)
@@ -156,7 +156,7 @@ variable "memories" {
     event_expiry_duration = optional(number, 90)
     execution_role_arn    = optional(string)
     encryption_key_arn    = optional(string)
-    
+
     strategies = optional(list(object({
       semantic_memory_strategy = optional(object({
         name        = optional(string)
@@ -225,7 +225,7 @@ variable "memories" {
         }))
       }))
     })), [])
-    
+
     tags = optional(map(string))
   }))
   default = {}
@@ -244,13 +244,13 @@ variable "memories" {
 variable "gateways" {
   description = "Map of AgentCore gateways to create. Each key is the gateway name."
   type = map(object({
-    description      = optional(string)
-    role_arn         = optional(string)
-    authorizer_type  = optional(string, "AWS_IAM")
-    protocol_type    = optional(string, "MCP")
-    exception_level  = optional(string, "DEBUG")
-    kms_key_arn      = optional(string)
-    
+    description     = optional(string)
+    role_arn        = optional(string)
+    authorizer_type = optional(string, "AWS_IAM")
+    protocol_type   = optional(string, "MCP")
+    exception_level = optional(string, "DEBUG")
+    kms_key_arn     = optional(string)
+
     authorizer_configuration = optional(object({
       custom_jwt_authorizer = object({
         allowed_audience = list(string)
@@ -258,7 +258,7 @@ variable "gateways" {
         discovery_url    = string
       })
     }))
-    
+
     protocol_configuration = optional(object({
       mcp = object({
         instructions       = optional(string)
@@ -266,7 +266,7 @@ variable "gateways" {
         supported_versions = optional(list(string), ["1.0.0"])
       })
     }))
-    
+
     interceptor_configurations = optional(list(object({
       interception_points = list(string)
       interceptor = object({
@@ -278,7 +278,7 @@ variable "gateways" {
         pass_request_headers = optional(bool, false)
       }))
     })), [])
-    
+
     tags = optional(map(string))
   }))
   default = {}
@@ -295,40 +295,40 @@ variable "gateways" {
 variable "gateway_targets" {
   description = "Map of AgentCore gateway targets to create. Each key is the target name."
   type = map(object({
-    gateway_name                = string
-    description                 = optional(string)
-    credential_provider_type    = optional(string)
-    
+    gateway_name             = string
+    description              = optional(string)
+    credential_provider_type = optional(string)
+
     api_key_config = optional(object({
       provider_arn              = string
       credential_location       = string
       credential_parameter_name = string
       credential_prefix         = optional(string)
     }))
-    
+
     oauth_config = optional(object({
       provider_arn      = string
       scopes            = optional(list(string))
       custom_parameters = optional(map(string))
     }))
-    
-    type = string # "LAMBDA" or "MCP_SERVER"
-    
+
+    type = string # "LAMBDA", "MCP_SERVER", "OPEN_API_SCHEMA", or "SMITHY_MODEL"
+
     lambda_config = optional(object({
       lambda_arn       = string
       tool_schema_type = string # "INLINE" or "S3"
-      
+
       inline_schema = optional(object({
         name        = string
         description = optional(string)
-        
+
         input_schema = object({
           type        = string
           description = optional(string)
           properties  = optional(list(any))
           items       = optional(any)
         })
-        
+
         output_schema = optional(object({
           type        = string
           description = optional(string)
@@ -336,15 +336,35 @@ variable "gateway_targets" {
           items       = optional(any)
         }))
       }))
-      
+
       s3_schema = optional(object({
         uri                     = string
         bucket_owner_account_id = optional(string)
       }))
     }))
-    
+
     mcp_server_config = optional(object({
       endpoint = string
+    }))
+
+    open_api_schema_config = optional(object({
+      inline_payload = optional(object({
+        payload = string
+      }))
+      s3 = optional(object({
+        uri                     = string
+        bucket_owner_account_id = optional(string)
+      }))
+    }))
+
+    smithy_model_config = optional(object({
+      inline_payload = optional(object({
+        payload = string
+      }))
+      s3 = optional(object({
+        uri                     = string
+        bucket_owner_account_id = optional(string)
+      }))
     }))
   }))
   default = {}
@@ -363,22 +383,22 @@ variable "gateway_targets" {
 variable "browsers" {
   description = "Map of AgentCore custom browsers to create. Each key is the browser name."
   type = map(object({
-    description          = optional(string)
-    execution_role_arn   = optional(string)
-    network_mode         = optional(string, "PUBLIC")
-    
+    description        = optional(string)
+    execution_role_arn = optional(string)
+    network_mode       = optional(string, "PUBLIC")
+
     network_configuration = optional(object({
       security_groups = list(string)
       subnets         = list(string)
     }))
-    
+
     recording_enabled = optional(bool, false)
-    
+
     recording_config = optional(object({
       bucket = string
       prefix = string
     }))
-    
+
     tags = optional(map(string))
   }))
   default = {}
@@ -389,15 +409,15 @@ variable "browsers" {
 variable "code_interpreters" {
   description = "Map of AgentCore custom code interpreters to create. Each key is the interpreter name."
   type = map(object({
-    description          = optional(string)
-    execution_role_arn   = optional(string)
-    network_mode         = optional(string, "SANDBOX")
-    
+    description        = optional(string)
+    execution_role_arn = optional(string)
+    network_mode       = optional(string, "SANDBOX")
+
     network_configuration = optional(object({
       security_groups = list(string)
       subnets         = list(string)
     }))
-    
+
     tags = optional(map(string))
   }))
   default = {}


### PR DESCRIPTION
# Terraform added features to configure a OpenAPI or a Smithy model to configure the MCP Gateway

## Issue Number
N/A

## Summary
Actually, the module don't let user use a custom JSONSchema nor a Smithy definition to configure the MCP Gateway. This PR add properties and IAC configuration to use those definition on the Gateways targets.

## Changes
### Major features
- Add possibility to use a OpenAPI model to define A MCP server capabilities
- Add possibility to use a Smithy document to define A MCP server capabilities

## Testing Results
### Static Tests
✅ checkov: 173 passed, 0 failed
✅ tflint: All checks passed
✅ markdownlint: No issues
✅ terraform-docs: README.md up to date
### Terraform Tests
✅ All 6 test files passing (100% pass rate)
✅ basic-code-runtime: Single CODE runtime with automatic build
✅ basic-container-runtime: Single CONTAINER runtime with Docker build
✅ complete: 57 resources, 2 actions (CODE + CONTAINER + all resource types)
### Manual Testing
✅ All examples deployed successfully
✅ CodeBuild builds complete with artifact verification
✅ Runtimes create successfully after builds complete
✅ No race conditions or "artifact not found" errors
✅ IAM propagation delays working correctly

## Checklist
 I have performed a self-review of this change
 [x] Changes have been tested (all tests passing)
 [x] Changes are documented (DEVELOPER_GUIDE.md, examples, README)

## Is this a breaking change?
No, by default changes won't affect existing resources.

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.